### PR TITLE
New elm_dependencies format required for elm compiler

### DIFF
--- a/Keyboard/Keys.elm
+++ b/Keyboard/Keys.elm
@@ -42,6 +42,10 @@ type Key =
  {keyCode: Keyboard.KeyCode
  ,name: String}
 
+{-| Two Keys are equal if their keyCodes are equal -}
+equal : Key -> Key -> Bool
+equal k0 k1 = k0.keyCode == k1.keyCode
+
 directionKeys: Key -> Key -> Key -> Key -> Signal { x:Int, y:Int }
 directionKeys up down right left = Keyboard.directions up.keyCode down.keyCode right.keyCode left.keyCode
 

--- a/Keyboard/Keys.elm
+++ b/Keyboard/Keys.elm
@@ -20,7 +20,7 @@ Note: undefined function keys have a conflict with the default keybindings of a 
 @docs arrowRight, arrowLeft, arrowUp, arrowDown, end, home, pageUp, pageDown
 
 ## Editing keys
-@docs tab, space, backspace, delete, insert
+@docs tab, space, backspace, delete, insert, enter
 
 ## Special keys
 @docs escape

--- a/elm_dependencies.json
+++ b/elm_dependencies.json
@@ -1,10 +1,10 @@
-{ "elm-version": "0.1"
-, "version": "1.0"
-, "summary": "Keyboard constants"
-, "description": "Constants refering to keycodes"
-, "license": "BSD3"
-, "repository": "https://github.com/timthelion/elm-key-constants.git"
-, "exposed-modules":
-    [ "Keyboard.Keys"
-    ]
+{
+    "version": "1.1",
+    "summary": "Keyboard constants",
+    "description": "Constants refering to keycodes",
+    "license": "BSD3",
+    "exposed-modules": ["Keyboard.keys"],
+    "elm-version": "0.1",
+    "dependencies": {},
+    "repository": "https://github.com/jcollard/elm-key-constants.git"
 }

--- a/elm_dependencies.json
+++ b/elm_dependencies.json
@@ -6,5 +6,5 @@
     "exposed-modules": ["Keyboard.keys"],
     "elm-version": "0.1",
     "dependencies": {},
-    "repository": "https://github.com/jcollard/elm-key-constants.git"
+    "repository": "https://github.com/timthelion/elm-key-constants.git"
 }

--- a/elm_dependencies.json
+++ b/elm_dependencies.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.2",
+    "version": "1.3",
     "summary": "Keyboard constants",
     "description": "Constants refering to keycodes",
     "license": "BSD3",
     "exposed-modules": ["Keyboard.keys"],
     "elm-version": "0.1",
     "dependencies": {},
-    "repository": "https://github.com/timthelion/elm-key-constants.git"
+    "repository": "https://github.com/jcollard/elm-key-constants.git"
 }

--- a/elm_dependencies.json
+++ b/elm_dependencies.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1",
+    "version": "1.2",
     "summary": "Keyboard constants",
     "description": "Constants refering to keycodes",
     "license": "BSD3",


### PR DESCRIPTION
When compiling as a dependency, an error occurs stating that the elm_dependencies file is missing a dependencies field.

I've added a dependencies field that is blank.
